### PR TITLE
make IB webpage cope with improved logging of `addOnTests`

### DIFF
--- a/cgi-bin/showAddOnLogs.py
+++ b/cgi-bin/showAddOnLogs.py
@@ -111,7 +111,7 @@ class LogViewer(object):
             # formatter.writeH3( "ERROR opening or reading logFile: "+logFileName )
             return passed, failed, timeout, notrun, stepOK, stepFail
         
-        logRe = re.compile('(cmsRun|cmsDriver.py)\s+(.*?)\s:\s([PF].*?D)\s.*')
+        logRe = re.compile('.*(cmsRun|cmsDriver.py)\s+(.*?)\s:\s([PF].*?D)\s.*')
 
         for line in lines:
 
@@ -259,10 +259,15 @@ class LogViewer(object):
 		    styleClass = xRest[dirName+':'+str(i)]
 		except:
 		    continue
+
                 cmd = cmdList[i]
-                lfPart = cmd.replace("'",'').replace('/','_').replace(' ',"_")
-                logFileName = 'cmsDriver-'+dirName+'_'+'%s.log' % lfPart
-                logFileName = self.findLogFile(logFileName)
+
+                logFileName = self.findLogFile('cmsDriver-'+dirName+'_'+'step%s.log' % (i+1))
+                # if no match, look for old-style naming of addOnTests logs
+                if not logFileName:
+                  lfPart = cmd.replace("'",'').replace('/','_').replace(' ',"_")
+                  logFileName = 'cmsDriver-'+dirName+'_'+'%s.log' % lfPart
+                  logFileName = self.findLogFile(logFileName)
 
                 outLine = '<a href="'+topCgiLogString+logFileName+'">'
                 if newStyle:

--- a/cgi-bin/showIB.py
+++ b/cgi-bin/showIB.py
@@ -350,7 +350,7 @@ class BuildViewer(object):
         passed = 0
         failed = 0
 
-        logRe = re.compile('(cmsRun|cmsDriver.py)\s+(.*?)\s:\s([PF].*?D)\s.*')
+        logRe = re.compile('.*(cmsRun|cmsDriver.py)\s+(.*?)\s:\s([PF].*?D)\s.*')
 
         for line in lines:
 


### PR DESCRIPTION
This PR provides the update needed to cope with the changes in https://github.com/cms-sw/cmssw/pull/40018 to the logs of the `addOnTests`.

It follows the suggestion by @smuzaffar in https://github.com/cms-sw/cmssw/pull/40018#issuecomment-1309492110.

I also included an analogous update in the script `cgi-bin/showIB.py`, but I'm not sure this is needed.

This PR is largely untested (unfortunately I'm not familiar with this package, and how its updates can be tested).
